### PR TITLE
Trigger build on any tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ trigger:
       - main
   tags:
     include:
-      - refs/tags/v*
+      - refs/tags/*
 
 pool:
   vmImage: ubuntu-latest


### PR DESCRIPTION
- Important for non 'vX.X.X'.  The build will publish and create the `v` version.  So for example `1.1.1` will publish and release as `v1.1.1`.