### PR TITLE
Add Support for selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.0
+
+-   ✨ Add a selection mode "jumpy2.toggleSelection", defaults to: <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>enter</kbd>. Thanks @FredBill1 for the PR!!!
+
 ## 1.3.0
 
 -   ✨ Add a little beacon after a jump. Best we can do now (easily) with the API. Thanks @FredBill1 for the PR!!!

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ code --install-extension davidlgoldberg.jumpy2
 -   Enter jump mode
     -   <kbd>shift</kbd> + <kbd>enter</kbd>
 -   Enter selection mode
-    -   <kbd>shift</kbd>  +  <kbd>alt</kbd> + <kbd>enter</kbd>
+    -   <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>enter</kbd>
 -   Reset first character entered
     -   <kbd>backspace</kbd>
 -   Cancel/exit jump mode (any of the following)
@@ -139,7 +139,7 @@ If you want the <kbd>backspace</kbd> key to work as the jumpy "reset" command yo
 
 (_feel free to bind it to another key as well_)
 
-### Bind 'f' key
+### Bind 'f' and/or 'F' key
 
 if <kbd>f</kbd> vim functionality is desired:
 open settings as json and add:
@@ -149,6 +149,10 @@ open settings as json and add:
     {
       "before": ["f"],
       "commands": ["jumpy2.toggle"]
+    },
+    {
+      "before": ["F"],
+      "commands": ["jumpy2.toggleSelection"]
     }
   ],
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ code --install-extension davidlgoldberg.jumpy2
 
 -   Enter jump mode
     -   <kbd>shift</kbd> + <kbd>enter</kbd>
+-   Enter selection mode
+    -   <kbd>shift</kbd>  +  <kbd>alt</kbd> + <kbd>enter</kbd>
 -   Reset first character entered
     -   <kbd>backspace</kbd>
 -   Cancel/exit jump mode (any of the following)

--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
                 "title": "Jumpy: Toggle"
             },
             {
+                "command": "jumpy2.toggleSelection",
+                "title": "Jumpy: Toggle Selection"
+            },
+            {
                 "command": "jumpy2.reset",
                 "title": "Jumpy: Reset"
             },
@@ -138,6 +142,11 @@
             {
                 "command": "jumpy2.toggle",
                 "key": "shift+enter",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "jumpy2.toggleSelection",
+                "key": "shift+alt+enter",
                 "when": "editorTextFocus"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,7 @@ const getSettings = (): Settings => {
 const statusBarItem = createStatusBar();
 
 let allLabels: Array<Label> = new Array<Label>();
+let isSelectionMode: boolean = false;
 
 // Subscribe:
 stateMachine.ports.validKeyEntered.subscribe((keyLabel: string) => {
@@ -57,7 +58,7 @@ stateMachine.ports.validKeyEntered.subscribe((keyLabel: string) => {
 stateMachine.ports.labelJumped.subscribe((keyLabel: string) => {
     const foundLabel = allLabels.find((label) => label.keyLabel === keyLabel);
     if (foundLabel) {
-        foundLabel.jump();
+        foundLabel.jump(isSelectionMode);
         reporter.sendTelemetryEvent(`jump-${keyLabel}`);
         const currentCount = (globalState.get(careerJumpsMadeKey) || 0) + 1;
         globalState.update(careerJumpsMadeKey, currentCount);
@@ -112,6 +113,13 @@ function enterJumpMode() {
 
 function toggle() {
     reporter.sendTelemetryEvent('toggle');
+    isSelectionMode = false;
+    enterJumpMode();
+}
+
+function toggleSelection() {
+    reporter.sendRawTelemetryEvent('toggleSelection');
+    isSelectionMode = true;
     enterJumpMode();
 }
 
@@ -170,6 +178,7 @@ export function activate(context: ExtensionContext) {
 
     subscriptions.push(
         registerCommand('jumpy2.toggle', toggle),
+        registerCommand('jumpy2.toggleSelection', toggleSelection),
         registerCommand('jumpy2.reset', reset),
         registerCommand('jumpy2.exit', exit),
         registerCommand('jumpy2.career', career)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ function toggle() {
 }
 
 function toggleSelection() {
-    reporter.sendRawTelemetryEvent('toggleSelection');
+    reporter.sendTelemetryEvent('toggleSelection');
     isSelectionMode = true;
     enterJumpMode();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,9 @@ stateMachine.ports.labelJumped.subscribe((keyLabel: string) => {
     if (foundLabel) {
         foundLabel.jump(isSelectionMode);
         foundLabel.animateBeacon();
-        reporter.sendTelemetryEvent(`jump-${keyLabel}`);
+        reporter.sendTelemetryEvent(
+            `${isSelectionMode ? 'selection-' : ''}jump-${keyLabel}`
+        );
         const currentCount = (globalState.get(careerJumpsMadeKey) || 0) + 1;
         globalState.update(careerJumpsMadeKey, currentCount);
         reporter.sendTelemetryEvent(`career-${currentCount}`);
@@ -119,7 +121,7 @@ function toggle() {
 }
 
 function toggleSelection() {
-    reporter.sendTelemetryEvent('toggleSelection');
+    reporter.sendTelemetryEvent('selectionToggle');
     isSelectionMode = true;
     enterJumpMode();
 }

--- a/src/label-interface.ts
+++ b/src/label-interface.ts
@@ -16,7 +16,7 @@ export interface Label {
     settings: Settings | undefined;
     getDecoration(): DecorationOptions;
     animateBeacon(input: any): void;
-    jump(): void;
+    jump(isSelectionMode: boolean): void;
     destroy(): void;
 }
 

--- a/src/labelers/words.ts
+++ b/src/labelers/words.ts
@@ -31,7 +31,7 @@ class WordLabel implements Label {
 
     animateBeacon() {}
 
-    async jump() {
+    async jump(isSelectionMode: boolean) {
         if (this.textEditor) {
             if (this.textEditor !== window.activeTextEditor) {
                 await window.showTextDocument(this.textEditor.document.uri, {
@@ -39,11 +39,10 @@ class WordLabel implements Label {
                     viewColumn: this.textEditor.viewColumn,
                 });
             }
+            const newActive = new Position(this.lineNumber, this.column);
             this.textEditor.selection = new Selection(
-                this.lineNumber,
-                this.column,
-                this.lineNumber,
-                this.column
+                isSelectionMode ? this.textEditor.selection.anchor : newActive,
+                newActive
             );
         }
     }


### PR DESCRIPTION
Hi, I've managed to implement #11 by introducing a global boolean variable named `isSelectionMode`, and added a boolean argument to the `Label.jump` interface. 

If the `Label.jump` is called with `isSelectionMode = true`, it will use the previous `this.textEditor.selection.anchor` as the new `Selection.anchor`, which will select the text between the previous anchor and the new active position from the label.

Here is a demo gif:

![selection mode](https://github.com/DavidLGoldberg/jumpy2/assets/36622430/36f03b2c-b676-474d-9986-d5082205ed2b)
