### PR TITLE
:rewind: Abandon postversion push experiment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,14 +18,6 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - checkout: self
-    clean: true
-    persistCredentials: true
-
-  - script: |
-      git fetch --all
-    displayName: 'Fetch All'
-
   - bash: |
       /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo '>>> Started xvfb'
     displayName: Start xvfb

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jumpy2",
     "displayName": "Jumpy2",
     "description": "A VS Code extension that creates dynamic hotkeys to jump around files across visible panes. It's a new 'Jumpy' but from the original author (Atom package) for VS Code. It works with the major VSC vim extensions and I plan to maintain it.",
-    "version": "1.2.0",
+    "version": "0.0.1",
     "engines": {
         "vscode": "^1.63.1"
     },
@@ -455,9 +455,7 @@
         "pretest": "npm run compile",
         "test": "nyc node ./out/test/runTest.js",
         "prepare": "npx husky install",
-        "deploy": "vsce publish",
-        "preversion": "git status && git branch --show-current && git fetch --all && git checkout main",
-        "postversion": "git status && git branch --show-current && git push origin main"
+        "deploy": "vsce publish"
     },
     "devDependencies": {
         "@types/glob": "7.2.0",


### PR DESCRIPTION
- I am restoring state to the code before this experiment to have the CI server commit back the version in the package.json.
- It's not really important.  The repo has the releases which generates the builds, and publishes to the vscode marketplace.  I don't really care that much about the version in the package.json as it will get overwritten by builds anyway.  I have made it 0.0.1 to avoid any weird issues with 0.0.0 and to be more obvious it's NOT real.  Wish there was an easier / safe way to comment in the package.json's.