### PR TITLE
:lipstick: Improve label border colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0
 
 -   ✨ Add ability to click Jumpy's status bar item to view your achievements.
+-   Improve default `jumpy2.labelBorderColor` to improve clarity when labels are adjacent.
 
 ## 1.5.2
 

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
                 "id": "jumpy2.labelBorderColor",
                 "description": "Border color for Jumpy2 labels.  Overrides dark, light, and highContrast, so theme specific overrides should apply.",
                 "defaults": {
-                    "dark": "#00F56A",
-                    "light": "#00F56A",
-                    "highContrast": "#00F56A"
+                    "dark": "#2d3236",
+                    "light": "#FFFFFF",
+                    "highContrast": "#2d3236"
                 }
             },
             {


### PR DESCRIPTION
- The bright green was kind of cool looking, but this will clarify label boundaries when labels are adjacent.  This is particularly useful with more aggressive regexes.